### PR TITLE
Allow emitting SubscribeEvent in Patcher

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/SubscribeEvent.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/SubscribeEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.eventbus.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used in Forge's EventBus as a magic annotation to subscribe to an event, this is just a marker for an optional Patchwork Patcher artifact.
+ * @deprecated This annotation should not be used by hybrid mods as it does nothing.
+ */
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = ElementType.METHOD)
+@Deprecated
+public @interface SubscribeEvent {
+}


### PR DESCRIPTION
I want to preserve forge's magic annotations so that the decompiled bytecode is easier to follow.